### PR TITLE
Fix compile error: client.c:1355:5: error: conflicting types for ‘recvmmsg'

### DIFF
--- a/client.c
+++ b/client.c
@@ -1352,7 +1352,7 @@ ssize_t send(int sockfd, const void *buf, size_t len, int flags) {
 	return sendto(sockfd, buf, len, flags, NULL, 0);
 }
 
-int recvmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags, struct timespec *timeout) {
+int recvmmsg_inner(int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags, struct timespec *timeout) {
 	ssize_t len;
 	int i, n;
 


### PR DESCRIPTION
Fix compile error: client.c:1355:5: error: conflicting types for ‘recvmmsg'

$ make
cc -O2 -Wall -g -fPIC   -c -o client.o client.c
client.c:1355:5: error: conflicting types for ‘recvmmsg’
 int recvmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags, struct timespec *timeout) {
     ^
In file included from client.c:23:0:
/usr/include/sys/socket.h:211:12: note: previous declaration of ‘recvmmsg’ was here
 extern int recvmmsg (int __fd, struct mmsghdr *__vmessages,
            ^
make: *** [client.o] Error 1

Because it have the same function name with library function: /usr/include/sys/socket.h:211.
And i saw it has not been called, so i think we can change it to recvmmsg_inner.

Signed-off-by: Qiao Zhao <qzhao@redhat.com>