### PR TITLE
add nodeX_stop config option

### DIFF
--- a/README
+++ b/README
@@ -125,6 +125,8 @@ Variables:
   the initial time error of the system clock in seconds, the default is 0
 - nodeX_start = float
   the time in seconds when will be the node started, the default is 0
+- nodeX_stop = float
+  the time in seconds when will be the node stopped, the default is 0 meaning never
 - nodeX_refclock = expr
   the reference clock time error in seconds, the clock can be accessed by the
   client via shared memory (NTP SHM protocol) or as a PTP hardware clock (PHC)

--- a/node.h
+++ b/node.h
@@ -35,6 +35,7 @@ class Node {
 	int fd;
 	int pending_request;
 	double start_time;
+	double stop_time;
 	double select_timeout;
 	bool select_read;
 	bool terminate;
@@ -47,6 +48,8 @@ class Node {
 	void set_fd(int fd);
 	int get_fd() const;
 	void set_start_time(double time);
+	void set_stop_time(double time);
+	bool terminating();
 	bool process_fd();
 	void reply(void *data, int len, int request);
 	void process_gettime();

--- a/server.cc
+++ b/server.cc
@@ -62,6 +62,8 @@ bool load_config(const char *file, Network *network, unsigned int nodes) {
 			network->get_node(node)->get_clock()->set_time(atof(arg));
 		else if (strncmp(var, "start", 5) == 0)
 			network->get_node(node)->set_start_time(atof(arg));
+		else if (strncmp(var, "stop", 4) == 0)
+			network->get_node(node)->set_stop_time(atof(arg));
 		else if (strncmp(var, "freq", 4) == 0) {
 			if (arg[0] == '(')
 				network->get_node(node)->get_clock()->set_freq_generator(generator.generate(arg));


### PR DESCRIPTION
I'm [extending ptp4l unicast tests](https://github.com/mlichvar/linuxptp-testsuite/pull/10) to test various failover modes, and having an option to stop the node after some time is very handy, as it allows to test for scenarios when selected best master goes away and the client needs to switch over.

With this small patch we get 'nodeX_stop' config option that allows to specify when the node should be stopped.