### PR TITLE
Support for non-blocking and read() on timerfd

### DIFF
--- a/client.c
+++ b/client.c
@@ -2543,7 +2543,7 @@ int getitimer(__itimer_which_t which, struct itimerval *curr_value) {
 int timerfd_create(int clockid, int flags) {
 	int t;
 
-	assert((clockid == CLOCK_REALTIME || clockid == CLOCK_MONOTONIC) && !flags);
+	assert((clockid == CLOCK_REALTIME || clockid == CLOCK_MONOTONIC) && !(flags & ~TFD_NONBLOCK));
 
 	t = get_free_timer();
 	if (t < 0) {


### PR DESCRIPTION
Dear @mlichvar ,

This PR add the following feature:
 - TFD_NONBLOCK flag on timerfd creation (relaxing the assert inside timerfd_create)
 - Support for read() call on timerfd, reporting the expirations number.

These changes are required in order to pass my changes on LinuxPTP (See https://github.com/richardcochran/linuxptp/pull/12).

Thanks a lot and ciao!

luigi